### PR TITLE
BlackboxExporter: Fix malformed rbac

### DIFF
--- a/deploy/2-blackboxExporter/rbac.yaml
+++ b/deploy/2-blackboxExporter/rbac.yaml
@@ -8,8 +8,7 @@ metadata: #@ metadata(data.values.blackboxExporterName, app=data.values.blackbox
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata:
-  name: #@ metadata(data.values.blackboxExporterName, app=data.values.blackboxExporterName, comp=data.values.blackboxExporterComponent, ver=data.values.blackboxExporterVersion)
+metadata: #@ metadata(data.values.blackboxExporterName, app=data.values.blackboxExporterName, comp=data.values.blackboxExporterComponent, ver=data.values.blackboxExporterVersion)
 rules:
 - apiGroups:
   - authentication.k8s.io


### PR DESCRIPTION
Previously, YTT generated this abomination:

```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name:
    labels:
      app.kubernetes.io/name: blackbox-exporter
      app.kubernetes.io/component: blackbox-exporter
      app.kubernetes.io/managed-by: ytt
      app.kubernetes.io/part-of: k8s-monitoring
      app.kubernetes.io/version: 0.19.0
    name: blackbox-exporter
```