### PR TITLE
Fix & uniformize the deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ The main reason for creating this project is to achieve a greater degree of flex
 
 ## Usage
 1. Create your local `data.yaml` (see `examples/data.yaml` in this repo)
-2. Execute `ytt -f data.yaml -f ...| kubectl apply --server-side -f -` TODO: Add command
+2. Execute `ytt -f data.yaml -f deploy | kubectl apply -f - --server-side`

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-ytt -f examples/data \
+ytt -f examples/data.yaml \
     -f deploy \
     | kubectl apply -f - --server-side


### PR DESCRIPTION
I fixed and uniformized the commands among `README.md` and `deploy.sh`.
Both of them were broken in separate ways.

I removed the `TODO`, since I didn't understand why it's there.